### PR TITLE
Fix initial directory being one folder level too high

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/listener/BrowseListener.java
+++ b/src/main/java/com/github/parker8283/bon2/listener/BrowseListener.java
@@ -39,7 +39,11 @@ public class BrowseListener extends MouseAdapter {
                 return "JAR mods only";
             }
         });
-        fileChooser.setCurrentDirectory(new File(Paths.get("").toAbsolutePath().getParent().toString()));
+        File currentDir = Paths.get("").toAbsolutePath().toFile();
+        while (!currentDir.isDirectory()) {
+            currentDir = currentDir.getParentFile();
+        }
+        fileChooser.setCurrentDirectory(currentDir);
     }
 
     @Override


### PR DESCRIPTION
I made a small derp when I initially made this feature. This new way should always get the current dir, or if that's not possible it will search upwards until it finds a directory.