### PR TITLE
Save selected forge version between runs. Fix some warnings

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/BON2.java
+++ b/src/main/java/com/github/parker8283/bon2/BON2.java
@@ -1,6 +1,8 @@
 package com.github.parker8283.bon2;
 
 import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -82,12 +84,22 @@ public class BON2 extends JFrame {
 
         lblForgeVer = new JLabel("Forge Version");
 
-        JComboBox forgeVersions = new JComboBox();
+        final JComboBox<String> forgeVersions = new JComboBox<String>();
 
         JButton btnRefreshVers = new JButton("Refresh");
         RefreshListener refresh = new RefreshListener(this, forgeVersions);
         btnRefreshVers.addMouseListener(refresh);
         refresh.mouseClicked(null); // update the versions initially
+        String lastVer = BONFiles.getSavedForgeVersion();
+        if (lastVer != null) {
+            forgeVersions.setSelectedItem(lastVer);
+        }
+        forgeVersions.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                BONFiles.saveForgeVersion(forgeVersions.getItemAt(forgeVersions.getSelectedIndex()));
+            }
+        });
 
         masterProgress = new JProgressBar();
 
@@ -151,14 +163,14 @@ public class BON2 extends JFrame {
     }
 
     private void addUrl(URL url) {
-        URLClassLoader sysloader = (URLClassLoader)BON2.class.getClassLoader();
-        Class sysclass = URLClassLoader.class;
+        URLClassLoader sysloader = (URLClassLoader) BON2.class.getClassLoader();
+        Class<URLClassLoader> sysclass = URLClassLoader.class;
         try {
-            //noinspection unchecked
+            // noinspection unchecked
             Method method = sysclass.getDeclaredMethod("addURL", URL.class);
             method.setAccessible(true);
             method.invoke(sysloader, url);
-        } catch(Exception e) {
+        } catch (Exception e) {
             JOptionPane.showMessageDialog(this, "Could not add library to classpath.\n" + e.toString(), ERROR_DIALOG_TITLE, JOptionPane.ERROR_MESSAGE);
         }
     }

--- a/src/main/java/com/github/parker8283/bon2/data/BONFiles.java
+++ b/src/main/java/com/github/parker8283/bon2/data/BONFiles.java
@@ -1,9 +1,15 @@
 package com.github.parker8283.bon2.data;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Scanner;
 
 public class BONFiles {
-    public static final File USER_GRADLE_FOLDER = new File(System.getProperty("user.home") + File.separator + ".gradle");
+    public static final File USER_HOME = new File(System.getProperty("user.home"));
+    public static final File BON_SAVE_DIR = new File(USER_HOME.getAbsolutePath() + File.separator + ".BON2");
+    public static final File FORGE_VERSION_FILE = new File(BON_SAVE_DIR.getAbsolutePath() + File.separator + "forge_version.txt");
+    public static final File USER_GRADLE_FOLDER = new File(USER_HOME.getAbsolutePath() + File.separator + ".gradle");
     public static final File GRADLE_CACHES_FOLDER = new File(USER_GRADLE_FOLDER, "caches");
     public static final File CACHES_MINECRAFT_FOLDER = new File(GRADLE_CACHES_FOLDER, "minecraft");
     public static final File MINECRAFT_NET_FOLDER = new File(CACHES_MINECRAFT_FOLDER, "net");
@@ -12,4 +18,38 @@ public class BONFiles {
     public static final File NET_MINECRAFT_FOLDER = new File(MINECRAFT_NET_FOLDER, "minecraft");
     public static final File CACHES_MODULES_FOLDER = new File(GRADLE_CACHES_FOLDER, "modules-2");
     public static final File MODULES_FILES_FOLDER = new File(CACHES_MODULES_FOLDER, "files-2.1");
+
+    static {
+        BON_SAVE_DIR.mkdirs();
+        try {
+            FORGE_VERSION_FILE.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getSavedForgeVersion() {
+        Scanner scan = null;
+        try {
+            scan = new Scanner(FORGE_VERSION_FILE);
+            return scan.nextLine();
+        } catch (Exception e) {
+            return null;
+        } finally {
+            if (scan != null) {
+                scan.close();
+            }
+        }
+    }
+
+    public static void saveForgeVersion(String ver) {
+        FileWriter fw = null;
+        try {
+            fw = new FileWriter(FORGE_VERSION_FILE);
+            fw.write(ver);
+            fw.close();
+        } catch (IOException e) {
+            ;
+        }
+    }
 }

--- a/src/main/java/com/github/parker8283/bon2/listener/RefreshListener.java
+++ b/src/main/java/com/github/parker8283/bon2/listener/RefreshListener.java
@@ -19,10 +19,10 @@ public class RefreshListener extends MouseAdapter {
     private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+(\\.\\d+)?(_\\w+)?-\\d+\\.\\d+\\.\\d+\\.\\d+(-.+)?");
 
     private Component parent;
-    private JComboBox comboBox;
+    private JComboBox<String> comboBox;
     private final Matcher versionMatcher = VERSION_PATTERN.matcher("");
 
-    public RefreshListener(Component parent, JComboBox comboBox) {
+    public RefreshListener(Component parent, JComboBox<String> comboBox) {
         this.parent = parent;
         this.comboBox = comboBox;
     }


### PR DESCRIPTION
I found it bothersome to have to pick the forge version from the ~30 I have in my dropdown every time I start it up, so it will now make a .BON2 file in the user home (which can be used for future data) and a forge_version.txt file in which it saves the last selected version.